### PR TITLE
Add more action input parameters and clarify usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A GitHub action from [Plasmo](https://www.plasmo.com/) to publish your browser e
 
 ## Usage
 
- In order to use this action, you will need to create a json file that contains the configuration for each browser you wish to publish to.
+ In order to use this action, you will need to create a json file that contains the keys and optional configuration for each browser you wish to publish to.
 
 To help you create it, we have provided a [JSON schema](https://json-schema.org/) that can be used with editors that support it, such as Visual Studio Code. This schema will provide intellisense and validation to ensure that your configuration is correct.
 
@@ -45,7 +45,7 @@ To help you create it, we have provided a [JSON schema](https://json-schema.org/
 
 > **NOTE**: You should only specify the browsers you wish to publish to. If there are any invalid configuration, the action will fail! I.e, no empty key allowed such as `"chrome": {}`.
 
-Each browser options is made of the following:
+Each browser option is made of the following:
 
 * Mandatory browser specific tokens (see [token guide](https://github.com/PlasmoHQ/bms/blob/main/tokens.md))
 
@@ -55,10 +55,10 @@ Each browser options is made of the following:
       `{version}` can be used in the name and will be replaced by the version in the manifest.json file.
 
     * `file`: An alias for the zip property.
+
+    * `verbose`: Enable verbose logging for the specific browser.
   
-    * `notes`: Provide notes for certification to the Edge Add-ons reviewers.
-  
-    * `verbose`: Enable verbose logging.
+    * `notes`: [Edge Only] Provide notes for certification to the Edge Add-ons reviewers.
 
 The final json might look like this:
 
@@ -79,7 +79,7 @@ The final json might look like this:
     "apiSecret": "e%f253^gh"
   },
   "edge": {
-    "zip": "chromium_addon.zip",
+    "zip": "chromium_addon_{version}.zip",
     "clientId": "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
     "clientSecret": "ab#c4de6fg",
     "productId": "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
@@ -102,18 +102,23 @@ steps:
 ```
 
 ## Action Input Parameters (`with`)
-> The non-required ones will **override** those in the keys file.
+The following parameters can be used to override the configuration in the keys file.
+Specifying options here will **override** those in the keys file.
 ```yaml
   keys:
     required: true
     description: "A JSON string containing the keys to be used for the submission process. (This should be a secret)"
   artifact:
-    required: false
-    description: "The extension zip artifact to be published."
     alias: [zip, file]
-  notes:
     required: false
-    description: "A release note cataloging changes. (Edge only)"
+    description: "The extension zip artifact to be published on all stores."
+  opera-file/chrome-file/firefox-file/edge-file:
+    required: false
+    description: "The file to be published to a specific store."
+  notes:
+    alias: [edge-notes]
+    required: false
+    description: "[Edge only] A release note cataloging changes."
   verbose:
     required: false
     description: "Print out more verbose logging."
@@ -121,6 +126,21 @@ steps:
     required: false
     description: "The path to a json file with a version field, default to package.json."
 ```
+
+###  Custom input parameters example
+```yaml
+steps:
+  - name: Browser Platform Publish
+    uses: PlasmoHQ/bpp@v3
+    with:
+      keys: ${{ secrets.BPP_KEYS }}
+      chrome-file: "chrome/myext_chromium_${{ env.EXT_VERSION }}.zip"
+      edge-file: "edge/myext_edge_${{ env.EXT_VERSION }}.zip"
+      edge-notes: "This is a test submission"
+      version-file: "src/manifest.json"
+      verbose: true
+```
+
 # Support
 
 Join the [Discord channel](https://www.plasmo.com/s/d)!

--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ Each browser option is made of the following:
 * Optional parameters:
     * `zip`: The zip file containing the extension. The manifest.json file must be in the root of the zip file.
   
-      `{version}` can be used in the name and will be replaced by the version in the manifest.json file.
+      `{version}` can be used in the name and will be replaced by the version from your versionFile.
 
     * `file`: An alias for the zip property.
 
     * `verbose`: Enable verbose logging for the specific browser.
+
+    * `versionFile`: Relative path to a json file which has a version field. Defaults to package.json
   
     * `notes`: [Edge Only] Provide notes for certification to the Edge Add-ons reviewers.
 
@@ -66,7 +68,7 @@ The final json might look like this:
 {
   "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v3/keys.schema.json",
   "chrome": {
-    "zip": "chromium_addon.zip",
+    "zip": "chromium_addon_{version}.zip",
     "clientId": "1280623",
     "clientSecret": "1!9us4",
     "refreshToken": "7&as$a89",
@@ -79,7 +81,7 @@ The final json might look like this:
     "apiSecret": "e%f253^gh"
   },
   "edge": {
-    "zip": "chromium_addon_{version}.zip",
+    "zip": "chromium_addon.zip",
     "clientId": "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
     "clientSecret": "ab#c4de6fg",
     "productId": "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ A GitHub action from [Plasmo](https://www.plasmo.com/) to publish your browser e
 
 ## Usage
 
-First, create a `keys.json` in your favorite text editor (preferably one that supports [json-schema](https://json-schema.org/)):
+ In order to use this action, you will need to create a json file that contains the configuration for each browser you wish to publish to.
+
+To help you create it, we have provided a [JSON schema](https://json-schema.org/) that can be used with editors that support it, such as Visual Studio Code. This schema will provide intellisense and validation to ensure that your configuration is correct.
 
 ```json
 {
@@ -41,11 +43,55 @@ First, create a `keys.json` in your favorite text editor (preferably one that su
 }
 ```
 
-A sample template is provided in [`keys.template.json`](./keys.template.json), and the JSON schema is in [`keys.schema.json`](./keys.schema.json). If your editor supports [json-schema](https://json-schema.org/), it should give you intellisense/autocompletion while working on the keys.
+> **NOTE**: You should only specify the browsers you wish to publish to. If there are any invalid configuration, the action will fail! I.e, no empty key allowed such as `"chrome": {}`.
 
-**NOTE**: You should only specify the browser you wish to publish to. If there are any invalid configuration, the action will fail! I.e, no empty key allowed such as `"chrome": {}`.
+Each browser options is made of the following:
 
-Copy the content of your `keys.json` into a github secret with a name of your choosing, in this case we used `BPP_KEYS`. Then, the action can be used as follows:
+* Mandatory browser specific tokens (see [token guide](https://github.com/PlasmoHQ/bms/blob/main/tokens.md))
+
+* Optional parameters:
+    * `zip`: The zip file containing the extension. The manifest.json file must be in the root of the zip file.
+  
+      `{version}` can be used in the name and will be replaced by the version in the manifest.json file.
+
+    * `file`: An alias for the zip property.
+  
+    * `notes`: Provide notes for certification to the Edge Add-ons reviewers.
+  
+    * `verbose`: Enable verbose logging.
+
+The final json might look like this:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v3/keys.schema.json",
+  "chrome": {
+    "zip": "chromium_addon.zip",
+    "clientId": "1280623",
+    "clientSecret": "1!9us4",
+    "refreshToken": "7&as$a89",
+    "extId": "akszypg"
+  },
+  "firefox": {
+    "file": "firefox_addon.xpi",
+    "extId": "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
+    "apiKey": "ab214c4d",
+    "apiSecret": "e%f253^gh"
+  },
+  "edge": {
+    "zip": "chromium_addon.zip",
+    "clientId": "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
+    "clientSecret": "ab#c4de6fg",
+    "productId": "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
+    "accessTokenUrl": "https://login.microsoftonline.com/aaaaaaa-aaaa-bbbb-cccc-dddddddddddd/oauth2/v2.0/token",
+    "notes": "This is a test submission"
+  }
+}
+```
+
+Once you got your json file, you will need to copy its content into a GitHub secret. You can do this by following the [instructions on creating encrypted secrets for a repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository). In this example, we will use the secret name `BPP_KEYS`.
+
+Then, the action can be used as follows:
 
 ```yaml
 steps:
@@ -55,19 +101,26 @@ steps:
       keys: ${{ secrets.BPP_KEYS }}
 ```
 
-**NOTE**: If you skipped the `zip` parameter in your keys, and your extension artifact is understood by the browser you specified, you can declare an `artifact` action parameter:
-
+## Action Input Parameters (`with`)
+> The non-required ones will **override** those in the keys file.
 ```yaml
-steps:
-  - name: Browser Platform Publish
-    uses: PlasmoHQ/bpp@v3
-    with:
-      artifact: build/artifact.zip
-      keys: ${{ secrets.BPP_KEYS }}
+  keys:
+    required: true
+    description: "A JSON string containing the keys to be used for the submission process. (This should be a secret)"
+  artifact:
+    required: false
+    description: "The extension zip artifact to be published."
+    alias: [zip, file]
+  notes:
+    required: false
+    description: "A release note cataloging changes. (Edge only)"
+  verbose:
+    required: false
+    description: "Print out more verbose logging."
+  version-file:
+    required: false
+    description: "The path to a json file with a version field, default to package.json."
 ```
-
-This works if you're targeting a group of browsers that share a similar format, such as Chrome or Edge.
-
 # Support
 
 Join the [Discord channel](https://www.plasmo.com/s/d)!

--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,24 @@ inputs:
   file:
     required: false
     description: "This is an alias to artifact argument."
+  chrome-file:
+    required: false
+    description: "The path to the Chrome extension zip file."
+  firefox-file:
+    required: false
+    description: "The path to the Firefox extension zip file."
+  edge-file:
+    required: false
+    description: "The path to the Edge extension zip file."
+  opera-file:
+    required: false
+    description: "The path to the Opera extension zip file."
   notes:
     required: false
     description: "A release note cataloging changes. (Edge only)"
+  edge-notes:
+    required: false
+    description: "This is an alias to notes argument."
   verbose:
     required: false
     description: "Print out more verbose logging."

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 inputs:
   keys:
     required: true
-    description: "A JSON string containing the keys to be used for the submission process."
+    description: "A JSON string containing the keys to be used for the submission process. (This should be a secret)"
   artifact:
     required: false
     description: "The extension zip artifact to be published."
@@ -19,7 +19,7 @@ inputs:
     description: "This is an alias to artifact argument."
   notes:
     required: false
-    description: "A release note cataloging changes."
+    description: "A release note cataloging changes. (Edge only)"
   verbose:
     required: false
     description: "Print out more verbose logging."

--- a/keys.schema.json
+++ b/keys.schema.json
@@ -34,7 +34,7 @@
       "properties": {
         "zip": {
           "type": "string",
-          "description": "The zip file containing the extension. manifest.json but be in the root of the zip file."
+          "description": "The zip file containing the extension. `{version}` can be used in the name and will be replaced by the version in the manifest.json file."
         },
         "file": {
           "type": "string",

--- a/packages/bpp/src/main.ts
+++ b/packages/bpp/src/main.ts
@@ -21,7 +21,9 @@ type Keys = {
 
 const tag = (prefix: string) => `${prefix.padEnd(9)} |`
 
-const hasBundleFile = (opt: CommonOptions) => !!opt.zip || !!opt.file
+const getBundleFiles = (opt: CommonOptions) => opt.zip || opt.file
+
+const hasBundleFile = (opt: CommonOptions) => !!getBundleFiles(opt)
 
 async function run(): Promise<void> {
   try {
@@ -33,7 +35,7 @@ async function run(): Promise<void> {
     const artifact = getInput("file") || getInput("zip") || getInput("artifact")
     const versionFile = getInput("version-file")
 
-    const notes = getInput("notes")
+    const edgeNotes = getInput("notes") || getInput("edge-notes")
 
     const verbose = !!getInput("verbose")
 
@@ -50,34 +52,40 @@ async function run(): Promise<void> {
       throw new Error("No supported browser found")
     }
 
-    const hasAtLeastOneZip =
-      !!artifact || browserEntries.some((b) => hasBundleFile(keys[b]))
+    for (const browser of browserEntries) {
+      const fromInput = getInput(`${browser}-file`)
+      const fromKeys = getBundleFiles(keys[browser])
+      if (fromInput) {
+        keys[browser].zip = fromInput
+      } else if (fromKeys) {
+        keys[browser].zip = fromKeys
+      } else if (artifact) {
+        keys[browser].zip = artifact
+      } else {
+        warning(
+          `${tag("🟡 SKIP")} No artifact available to submit for ${browser}`
+        )
+      }
+
+      // override keys value if verbose/versionFile action input is set
+      if (verbose) {
+        keys[browser].verbose = verbose
+      }
+
+      if (versionFile) {
+        keys[browser].versionFile = versionFile
+      }
+    }
+
+    const hasAtLeastOneZip = browserEntries.some((b) => hasBundleFile(keys[b]))
 
     if (!hasAtLeastOneZip) {
       throw new Error("No artifact found for deployment")
     }
 
-    // Enrich keys with zip artifact and notes as needed
-    browserEntries.forEach((browser: BrowserName) => {
-      if (!hasBundleFile(keys[browser])) {
-        if (!artifact) {
-          warning(
-            `${tag("🟡 SKIP")} No artifact available to submit for ${browser}`
-          )
-        } else {
-          keys[browser].zip = artifact
-        }
-      }
-      if (!keys[browser].versionFile) {
-        keys[browser].versionFile = versionFile
-      }
-
-      if (!!notes) {
-        keys[browser].notes = notes
-      }
-
-      keys[browser].verbose = verbose
-    })
+    if (keys.edge && edgeNotes) {
+        keys.edge.notes = edgeNotes
+    }
 
     if (process.env.NODE_ENV === "test") {
       debug(JSON.stringify({ artifact, versionFile, verbose }))

--- a/packages/bpp/src/main.ts
+++ b/packages/bpp/src/main.ts
@@ -84,7 +84,7 @@ async function run(): Promise<void> {
     }
 
     if (keys.edge && edgeNotes) {
-        keys.edge.notes = edgeNotes
+      keys.edge.notes = edgeNotes
     }
 
     if (process.env.NODE_ENV === "test") {


### PR DESCRIPTION
done at the suggestion of @louisgv on the discord

The json schema wasn't really changed reguarding the `edge-notes` but I'm not sure if it should be anyways since it's also used by https://github.com/PlasmoHQ/bms