### PR TITLE
feat: firefox source code submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Each browser option is made of the following:
 
     * `versionFile`: Relative path to a json file which has a version field. Defaults to package.json
   
+    * `sourceZip`: The zip file containing the source code for Firefox submissions.
+
+    * `source` and `sourceFile`: Aliases for the `sourceZip` property.
+
     * `notes`: [Edge Only] Provide notes for certification to the Edge Add-ons reviewers.
 
 The final json might look like this:
@@ -76,6 +80,7 @@ The final json might look like this:
   },
   "firefox": {
     "file": "firefox_addon.xpi",
+    "sourceFile": "source.zip",
     "extId": "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
     "apiKey": "ab214c4d",
     "apiSecret": "e%f253^gh"
@@ -117,6 +122,10 @@ Specifying options here will **override** those in the keys file.
   opera-file/chrome-file/firefox-file/edge-file:
     required: false
     description: "The file to be published to a specific store."
+  source:
+    alias: [source-zip, source-file]
+    required: false
+    description: "The extension source zip artifact for Firefox submissions."
   notes:
     alias: [edge-notes]
     required: false

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,15 @@ inputs:
   notes:
     required: false
     description: "A release note cataloging changes. (Edge only)"
+  source:
+    required: false
+    description: "The extension source zip file."
+  source-zip:
+    required: false
+    description: "This is an alias to source argument."
+  source-file:
+    required: false
+    description: "This is an alias to source argument."
   edge-notes:
     required: false
     description: "This is an alias to notes argument."

--- a/packages/bpp/src/main.ts
+++ b/packages/bpp/src/main.ts
@@ -36,6 +36,9 @@ async function run(): Promise<void> {
     const keys: Keys = JSON.parse(getInput("keys", { required: true }))
     // Path to the zip file to be deployed
     const artifact = getInput("file") || getInput("zip") || getInput("artifact")
+    // Path to the source zip file for firefox submissions
+    const source = getInput("source") || getInput("sourceFile") || getInput("sourceZip")
+
     const versionFile = getInput("version-file")
 
     const edgeNotes = getInput("notes") || getInput("edge-notes")
@@ -84,6 +87,10 @@ async function run(): Promise<void> {
 
     if (!hasAtLeastOneZip) {
       throw new Error("No artifact found for deployment")
+    }
+
+    if (keys.firefox && source) {
+      keys.firefox.sourceZip = source
     }
 
     if (keys.edge && edgeNotes) {


### PR DESCRIPTION
## Changes
- expose `source`, `source-zip` and `source-file` parameters in `bpp` to allow submission of source code which is required by firefox for bundled extensions
- amended `bms` package to expose the underlying submission keys