### PR TITLE
feat(node): use node20 in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,5 +51,5 @@ inputs:
     required: false
     description: "The path to a json file with a version field, default to package.json."
 runs:
-  using: "node16"
+  using: "node20"
   main: "index.js"


### PR DESCRIPTION
Node 16 is no longer LTS. GitHub is moving all actions to use Node v20 by default ([source](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)). This PR updates this so there are no forces and, hopefully, no longer warnings