### PR TITLE
fix: source-zip, source-file alias input value fix

### DIFF
--- a/packages/bpp/src/main.ts
+++ b/packages/bpp/src/main.ts
@@ -37,7 +37,7 @@ async function run(): Promise<void> {
     // Path to the zip file to be deployed
     const artifact = getInput("file") || getInput("zip") || getInput("artifact")
     // Path to the source zip file for firefox submissions
-    const source = getInput("source") || getInput("sourceFile") || getInput("sourceZip")
+    const source = getInput("source") || getInput("source-file") || getInput("source-zip")
 
     const versionFile = getInput("version-file")
 


### PR DESCRIPTION
Aligned `source-file` and `source-zip` alias input values with schema naming. `sourceFile` and `sourceZip` were not previously accepted

<img width="695" alt="Screenshot 2025-01-11 at 12 01 31 AM" src="https://github.com/user-attachments/assets/1f6867e0-992c-4306-a009-031f691f1bdd" />
