### PR TITLE
fix: docs that align with firefox uuid style

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The final json might look like this:
   "firefox": {
     "file": "firefox_addon.xpi",
     "sourceFile": "source.zip",
-    "extId": "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
+    "extId": "akszypg",
     "apiKey": "ab214c4d",
     "apiSecret": "e%f253^gh"
   },

--- a/keys.schema.json
+++ b/keys.schema.json
@@ -104,7 +104,7 @@
         },
         "extId": {
           "type": "string",
-          "description": "This is the extension UUID, get it from https://addons.mozilla.org/en-US/developers/addon/{ext-name}/edit, under Technical Details. If it is embedded in your manifest under gecko.id, omit this property."
+          "description": "This is the extension UUID from https://addons.mozilla.org/en-US/developers/addon/EXT_ID/edit under Technical Details, or the URL slug. If it is embedded in your manifest under gecko.id, omit this property."
         },
         "license": {
           "type": "string",

--- a/keys.template.json
+++ b/keys.template.json
@@ -8,7 +8,7 @@
     "uploadOnly": true
   },
   "firefox": {
-    "extId": "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
+    "extId": "abcd",
     "apiKey": "abcd",
     "apiSecret": "efgh"
   },


### PR DESCRIPTION
## Changes
Adjusted the README and key template styling for `extId` for Firefox uploads. Typically this takes the shape of the URL slug or email address now.